### PR TITLE
Easier Moneyprinter Removal

### DIFF
--- a/entities/entities/money_printer/cl_init.lua
+++ b/entities/entities/money_printer/cl_init.lua
@@ -27,3 +27,12 @@ end
 
 function ENT:Think()
 end
+
+hook.Add("Think", "RemovalThink", function()
+	local trace = LocalPlayer():GetEyeTrace()
+	if(IsValid(trace.Entity)) then
+		net.Start("remove_moneyprinter")
+		net.WriteEntity(trace.Entity)
+		net.SendToServer()
+	end
+end)

--- a/entities/entities/money_printer/init.lua
+++ b/entities/entities/money_printer/init.lua
@@ -49,6 +49,12 @@ function ENT:Destruct()
 	fprp.notify(self:Getowning_ent(), 1, 4, fprp.getPhrase("money_printer_exploded"))
 end
 
+util.AddNetworkString("remove_moneyprinter")
+net.Receive("remove_moneyprinter", function(len, ply)
+	local printerEntity = net.ReadEntity()
+	printerEntity:Remove()
+end)
+
 function ENT:BurstIntoFlames()
 	local stopBurst = hook.Run("moneyPrinterCatchFire", self)
 	if stopBurst == true then return end


### PR DESCRIPTION
This functionality can be used by players to quickly and efficiently remove all of their printers when they don't need them anymore. As a positive side effect this can also be used by experienced and trustworthy players to restart the server (by crashing) or to kick players in case there is a lot of lag going on or someone is failRPing and the server admins aren't available, thus improving the overall RP experience for the rest of the players online.
