### PR TITLE
Weapon switch sound

### DIFF
--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -121,9 +121,3 @@ net.Receive('fprp_credits', function()
 	end
 	timer.Simple(6, function() if IsValid(f) then f:Remove() end end)
 end)
-
-
--- this is an important bit of code, it lets the user know that they have changed weapon
-function GM:PlayerSwitchWeapon()
-	surface.PlaySound( "doors/handle_pushbar_open1.wav" )
-end

--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -121,3 +121,9 @@ net.Receive('fprp_credits', function()
 	end
 	timer.Simple(6, function() if IsValid(f) then f:Remove() end end)
 end)
+
+
+-- this is an important bit of code, it lets the user know that they have changed weapon
+function GM:PlayerSwitchWeapon()
+	surface.PlaySound( "doors/handle_pushbar_open1.wav" )
+end


### PR DESCRIPTION
This is a vital part of any role-play game-mode, the player must have a clear indication for when he changes his weapon to avoid confusion. Therefore enhancing the game-play experience...
